### PR TITLE
fix: cycleway:*=opposite_lane

### DIFF
--- a/Controllers/Overlays/RoadsController.cs
+++ b/Controllers/Overlays/RoadsController.cs
@@ -208,7 +208,7 @@ namespace osm_road_overlay.Controllers.Overlays
 
             var cycleway = way.Tags.GetValueOrDefault("cycleway", "no");
             var cyclewayBoth = way.Tags.GetValueOrDefault("cycleway:both", "no");
-            if (cycleway == "lane" || cyclewayBoth == "lane") {
+            if (cycleway == "lane" || cyclewayBoth == "lane" || cyclewayBoth == "opposite_lane") {
                 lanes.Insert(0, new Lane(LaneType.Cycle, LaneWidthCycle));
                 lanes.Add(new Lane(LaneType.Cycle, LaneWidthCycle));
                 center += LaneWidthCycle;
@@ -217,11 +217,11 @@ namespace osm_road_overlay.Controllers.Overlays
             } else {
                 var cyclewayLeft = way.Tags.GetValueOrDefault("cycleway:left", "no");
                 var cyclewayRight = way.Tags.GetValueOrDefault("cycleway:right", "no");
-                if (cyclewayLeft == "lane" || cyclewayRight == "opposite_lane") {
+                if (cyclewayLeft == "lane" || cyclewayLeft == "opposite_lane") {
                     lanes.Insert(0, new Lane(LaneType.Cycle, LaneWidthCycle));
                     center += LaneWidthCycle;
                 }
-                if (cyclewayLeft == "opposite_lane" || cyclewayRight == "lane") {
+                if (cyclewayRight == "lane" || cyclewayRight == "opposite_lane") {
                     lanes.Add(new Lane(LaneType.Cycle, LaneWidthCycle));
                 }
             }


### PR DESCRIPTION
Somehow cycleway:both=opposite_lane got dropped in a commit.
https://github.com/twpol/osm-tiles/commit/1a27b345f52d1b7097db3c8ec32be20e5e2c545d#diff-ddcd9a7cff6676044b86ffc843380e92